### PR TITLE
feat(glowm): add interactive pager

### DIFF
--- a/tools/glowm/README.md
+++ b/tools/glowm/README.md
@@ -98,3 +98,38 @@ H1 headings render as pill-style labels (black text on blue background, padded, 
 ### Indentation
 
 Paragraphs and headings are indented for better readability.
+
+## Pager Mode
+
+For long documents, glowm automatically activates a `less`-like pager when:
+- Output is to a TTY (not piped)
+- Content exceeds terminal height
+
+### Keyboard Shortcuts
+
+| Key | Action |
+|-----|--------|
+| `j` / `↓` | Scroll down one line |
+| `k` / `↑` | Scroll up one line |
+| `Space` / `f` | Page down |
+| `b` | Page up |
+| `d` | Half page down |
+| `u` | Half page up |
+| `g` | Go to top |
+| `G` | Go to bottom |
+| `/` | Search forward |
+| `?` | Search backward |
+| `n` | Next match |
+| `N` | Previous match |
+| `=` | Show position info |
+| `q` | Quit |
+
+### Bypassing the Pager
+
+```bash
+# Use --no-pager flag
+glowm --no-pager README.md
+
+# Piping always bypasses pager
+glowm README.md | head -50
+```

--- a/tools/glowm/glowm.test.ts
+++ b/tools/glowm/glowm.test.ts
@@ -34,7 +34,7 @@ function hasAnsiColor(s: string): boolean {
 }
 
 function stripAnsi(s: string): string {
-  return s.replace(/\x1b\[[0-9;]*m/g, '')
+  return s.replace(/\x1b\[[0-9;]*m/g, '').replace(/\x01/g, '')
 }
 
 function renderMarkdown(md: string): string {

--- a/tools/glowm/glowm.ts
+++ b/tools/glowm/glowm.ts
@@ -7,6 +7,8 @@ import { markedTerminal } from 'marked-terminal'
 
 import { terminalColors } from './lib/colors'
 import { outputWithImages, prepareImages } from './lib/images'
+import { splitIntoLines } from './lib/lines'
+import { runPager } from './lib/pager'
 import {
   addBlockquotePipe,
   addCodeBlockBox,
@@ -36,11 +38,54 @@ export {
 }
 export type { TerminalExtension }
 
+type ImageData = {
+  buffer: Buffer
+  alt: string
+}
+
+/** Check if we should use the pager. */
+function shouldPaginate(
+  content: string,
+  images: Map<string, ImageData>,
+  noPager: boolean
+): boolean {
+  // Respect --no-pager flag
+  if (noPager) return false
+
+  // Don't paginate if not a TTY (allows piping)
+  if (!process.stdout.isTTY) return false
+
+  // Calculate total visual lines
+  const termWidth = process.stdout.columns || 80
+  const termHeight = process.stdout.rows || 24
+  const lines = splitIntoLines(content, termWidth)
+
+  // TODO: Account for image heights
+  return lines.length > termHeight
+}
+
+/** Parse CLI arguments. */
+function parseArgs(): { filePath?: string; noPager: boolean } {
+  const args = process.argv.slice(2)
+  let filePath: string | undefined
+  let noPager = false
+
+  for (const arg of args) {
+    if (arg === '--no-pager') {
+      noPager = true
+    } else if (!arg.startsWith('-')) {
+      filePath = arg
+    }
+  }
+
+  return { filePath, noPager }
+}
+
 async function main(): Promise<void> {
-  const filePath = process.argv[2]
+  const { filePath, noPager } = parseArgs()
   const basePath = filePath ? path.dirname(path.resolve(filePath)) : undefined
 
-  const markdown = await readInput()
+  const markdown = await readInput(filePath)
   const withMermaid = replaceMermaidBlocks(markdown)
   const { markdown: withPlaceholders, images } = await prepareImages(withMermaid, basePath)
 
@@ -60,7 +105,12 @@ async function main(): Promise<void> {
   marked.use(ext)
 
   const rendered = '\n\n' + (marked(withPlaceholders) as string)
-  await outputWithImages(rendered, images)
+
+  if (shouldPaginate(rendered, images, noPager)) {
+    await runPager(rendered, images)
+  } else {
+    await outputWithImages(rendered, images)
+  }
 }
 
 if (import.meta.main) {

--- a/tools/glowm/lib/ansi.test.ts
+++ b/tools/glowm/lib/ansi.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  stripAnsi,
+  visibleLength,
+  buildPositionMap,
+  injectHighlight,
+  ANSI,
+} from './ansi'
+
+describe('stripAnsi', () => {
+  test('removes color codes', () => {
+    expect(stripAnsi('\x1b[31mred\x1b[0m')).toBe('red')
+  })
+
+  test('handles multiple codes', () => {
+    expect(stripAnsi('\x1b[1m\x1b[31mbold red\x1b[0m')).toBe('bold red')
+  })
+
+  test('returns plain text unchanged', () => {
+    expect(stripAnsi('plain')).toBe('plain')
+  })
+})
+
+describe('visibleLength', () => {
+  test('ignores ANSI codes in length calculation', () => {
+    expect(visibleLength('\x1b[31mred\x1b[0m')).toBe(3)
+  })
+
+  test('counts visible characters only', () => {
+    expect(visibleLength('\x1b[1m\x1b[31mAB\x1b[0m')).toBe(2)
+  })
+})
+
+describe('buildPositionMap', () => {
+  test('maps visible positions to ANSI positions', () => {
+    const map = buildPositionMap('\x1b[31mABC\x1b[0m')
+    // visible index 0 (A) -> ansi index 5 (after \x1b[31m)
+    expect(map[0]).toBe(5)
+    expect(map[1]).toBe(6)
+    expect(map[2]).toBe(7)
+  })
+
+  test('handles plain text', () => {
+    const map = buildPositionMap('ABC')
+    expect(map[0]).toBe(0)
+    expect(map[1]).toBe(1)
+    expect(map[2]).toBe(2)
+  })
+})
+
+describe('injectHighlight', () => {
+  test('wraps range in inverse video', () => {
+    const result = injectHighlight('hello world', 0, 5)
+    expect(result).toBe('\x1b[7mhello\x1b[27m world')
+  })
+
+  test('works with ANSI-colored text', () => {
+    const input = '\x1b[31mhello\x1b[0m world'
+    const result = injectHighlight(input, 0, 5)
+    // Should highlight "hello" (visible positions 0-4)
+    expect(result).toContain('\x1b[7m')
+    expect(result).toContain('\x1b[27m')
+    expect(stripAnsi(result)).toBe('hello world')
+  })
+})
+
+describe('ANSI escape sequences', () => {
+  test('clearScreen is defined', () => {
+    expect(ANSI.clearScreen).toBe('\x1b[2J')
+  })
+
+  test('cursorHome is defined', () => {
+    expect(ANSI.cursorHome).toBe('\x1b[H')
+  })
+
+  test('cursorHide is defined', () => {
+    expect(ANSI.cursorHide).toBe('\x1b[?25l')
+  })
+
+  test('cursorShow is defined', () => {
+    expect(ANSI.cursorShow).toBe('\x1b[?25h')
+  })
+})

--- a/tools/glowm/lib/ansi.ts
+++ b/tools/glowm/lib/ansi.ts
@@ -1,0 +1,69 @@
+const ANSI_REGEX = /\x1b\[[0-9;]*m/g
+
+/** ANSI escape sequences for terminal control. */
+export const ANSI = {
+  clearScreen: '\x1b[2J',
+  cursorHome: '\x1b[H',
+  cursorHide: '\x1b[?25l',
+  cursorShow: '\x1b[?25h',
+  cursorTo: (row: number, col: number) => `\x1b[${row};${col}H`,
+  eraseLine: '\x1b[2K',
+  highlightStart: '\x1b[7m', // Inverse video
+  highlightEnd: '\x1b[27m',
+} as const
+
+/** Strip ANSI escape codes from string. */
+export function stripAnsi(s: string): string {
+  return s.replace(ANSI_REGEX, '')
+}
+
+/** Get visible length of string (excluding ANSI codes). */
+export function visibleLength(s: string): number {
+  return stripAnsi(s).length
+}
+
+/**
+ * Build map from visible character index to ANSI string index.
+ * Returns array where map[visibleIdx] = ansiIdx.
+ */
+export function buildPositionMap(s: string): number[] {
+  const map: number[] = []
+  let visibleIdx = 0
+  let i = 0
+
+  while (i < s.length) {
+    // Check for ANSI escape sequence
+    const match = s.slice(i).match(/^\x1b\[[0-9;]*m/)
+    if (match) {
+      i += match[0].length
+      continue
+    }
+    map[visibleIdx] = i
+    visibleIdx++
+    i++
+  }
+
+  return map
+}
+
+/**
+ * Inject highlight (inverse video) around visible character range.
+ * @param s - String possibly containing ANSI codes
+ * @param start - Start visible index (inclusive)
+ * @param end - End visible index (exclusive)
+ */
+export function injectHighlight(s: string, start: number, end: number): string {
+  const map = buildPositionMap(s)
+  if (start >= map.length || end > map.length) return s
+
+  const ansiStart = map[start]!
+  const ansiEnd = end < map.length ? map[end]! : s.length
+
+  return (
+    s.slice(0, ansiStart) +
+    ANSI.highlightStart +
+    s.slice(ansiStart, ansiEnd) +
+    ANSI.highlightEnd +
+    s.slice(ansiEnd)
+  )
+}

--- a/tools/glowm/lib/ansi.ts
+++ b/tools/glowm/lib/ansi.ts
@@ -10,6 +10,8 @@ export const ANSI = {
   eraseLine: '\x1b[2K',
   highlightStart: '\x1b[7m', // Inverse video
   highlightEnd: '\x1b[27m',
+  mouseOn: '\x1b[?1000h\x1b[?1006h', // Enable SGR mouse mode
+  mouseOff: '\x1b[?1000l\x1b[?1006l', // Disable SGR mouse mode
 } as const
 
 /** Strip ANSI escape codes from string. */

--- a/tools/glowm/lib/images.ts
+++ b/tools/glowm/lib/images.ts
@@ -305,3 +305,40 @@ function formatFallback(alt: string, src: string, link?: string): string {
   }
   return `${IMAGE_INDENT}${label} ${styledPath}`
 }
+
+/**
+ * Render single image to stdout (for pager use).
+ * Returns approximate height in rows.
+ */
+export async function renderImage(
+  imageData: ImageData,
+  isKittySupported: boolean
+): Promise<number> {
+  const { buffer, alt } = imageData
+  const imageColumns = calculateImageColumns()
+
+  process.stdout.write('\n')
+
+  if (isKittySupported) {
+    process.stdout.write(IMAGE_INDENT)
+    writeKittyImage(buffer)
+  } else {
+    const rendered = await terminalImage.buffer(buffer, {
+      width: IMAGE_WIDTH,
+      preferNativeRender: false,
+    })
+    const indented = rendered
+      .split('\n')
+      .map(line => (line ? IMAGE_INDENT + line : line))
+      .join('\n')
+    process.stdout.write(indented)
+  }
+
+  process.stdout.write(formatCaption(alt, imageColumns))
+
+  // Return approximate height in rows (rough estimate)
+  // TODO: Calculate actual height from image dimensions
+  return 10
+}
+
+export type { ImageData }

--- a/tools/glowm/lib/images.ts
+++ b/tools/glowm/lib/images.ts
@@ -5,6 +5,7 @@ import supportsTerminalGraphics from 'supports-terminal-graphics'
 import terminalImage from 'terminal-image'
 
 import { colors } from './colors'
+import { HEADING_MARKER } from './renderers'
 
 // Linked image: [![alt](img)](url) - must match before plain image
 const LINKED_IMAGE_REGEX = /\[!\[([^\]]*)\]\(([^)]+)\)\]\(([^)]+)\)/g
@@ -91,14 +92,17 @@ export async function outputWithImages(
 ): Promise<void> {
   const isKittySupported = useKittyProtocol()
 
+  // Strip heading markers (used by pager for navigation)
+  const content = rendered.replaceAll(HEADING_MARKER, '')
+
   // Find all placeholders and split content
   const placeholderRegex = /\x00IMG:\d+\x00/g
   let lastIndex = 0
   let match: RegExpExecArray | null
 
-  while ((match = placeholderRegex.exec(rendered)) !== null) {
+  while ((match = placeholderRegex.exec(content)) !== null) {
     // Output text before placeholder
-    const textBefore = rendered.slice(lastIndex, match.index)
+    const textBefore = content.slice(lastIndex, match.index)
     if (textBefore) process.stdout.write(textBefore)
 
     // Output image
@@ -112,7 +116,7 @@ export async function outputWithImages(
   }
 
   // Output remaining text
-  const remaining = rendered.slice(lastIndex)
+  const remaining = content.slice(lastIndex)
   if (remaining) process.stdout.write(remaining)
 }
 

--- a/tools/glowm/lib/keys.test.ts
+++ b/tools/glowm/lib/keys.test.ts
@@ -35,12 +35,20 @@ describe('parseKey', () => {
     expect(parseKey('/')).toBe(KEY.SEARCH)
   })
 
-  test('recognizes n as next match', () => {
-    expect(parseKey('n')).toBe(KEY.NEXT_MATCH)
+  test('recognizes n as next header', () => {
+    expect(parseKey('n')).toBe(KEY.NEXT_HEADER)
   })
 
-  test('recognizes N as prev match', () => {
-    expect(parseKey('N')).toBe(KEY.PREV_MATCH)
+  test('recognizes N as prev header', () => {
+    expect(parseKey('N')).toBe(KEY.PREV_HEADER)
+  })
+
+  test('recognizes Ctrl+N as next match', () => {
+    expect(parseKey('\x0e')).toBe(KEY.NEXT_MATCH)
+  })
+
+  test('recognizes Ctrl+P as prev match', () => {
+    expect(parseKey('\x10')).toBe(KEY.PREV_MATCH)
   })
 
   test('recognizes = as info', () => {

--- a/tools/glowm/lib/keys.test.ts
+++ b/tools/glowm/lib/keys.test.ts
@@ -1,0 +1,77 @@
+// lib/keys.test.ts
+import { describe, expect, test } from 'bun:test'
+import { parseKey, KEY } from './keys'
+
+describe('parseKey', () => {
+  test('recognizes j as down', () => {
+    expect(parseKey('j')).toBe(KEY.DOWN)
+  })
+
+  test('recognizes k as up', () => {
+    expect(parseKey('k')).toBe(KEY.UP)
+  })
+
+  test('recognizes space as page down', () => {
+    expect(parseKey(' ')).toBe(KEY.PAGE_DOWN)
+  })
+
+  test('recognizes b as page up', () => {
+    expect(parseKey('b')).toBe(KEY.PAGE_UP)
+  })
+
+  test('recognizes q as quit', () => {
+    expect(parseKey('q')).toBe(KEY.QUIT)
+  })
+
+  test('recognizes g as top', () => {
+    expect(parseKey('g')).toBe(KEY.TOP)
+  })
+
+  test('recognizes G as bottom', () => {
+    expect(parseKey('G')).toBe(KEY.BOTTOM)
+  })
+
+  test('recognizes / as search', () => {
+    expect(parseKey('/')).toBe(KEY.SEARCH)
+  })
+
+  test('recognizes n as next match', () => {
+    expect(parseKey('n')).toBe(KEY.NEXT_MATCH)
+  })
+
+  test('recognizes N as prev match', () => {
+    expect(parseKey('N')).toBe(KEY.PREV_MATCH)
+  })
+
+  test('recognizes = as info', () => {
+    expect(parseKey('=')).toBe(KEY.INFO)
+  })
+
+  test('recognizes down arrow', () => {
+    expect(parseKey('\x1b[B')).toBe(KEY.DOWN)
+  })
+
+  test('recognizes up arrow', () => {
+    expect(parseKey('\x1b[A')).toBe(KEY.UP)
+  })
+
+  test('recognizes Ctrl+F as page down', () => {
+    expect(parseKey('\x06')).toBe(KEY.PAGE_DOWN)
+  })
+
+  test('recognizes Ctrl+B as page up', () => {
+    expect(parseKey('\x02')).toBe(KEY.PAGE_UP)
+  })
+
+  test('recognizes Ctrl+D as half page down', () => {
+    expect(parseKey('\x04')).toBe(KEY.HALF_DOWN)
+  })
+
+  test('recognizes Ctrl+U as half page up', () => {
+    expect(parseKey('\x15')).toBe(KEY.HALF_UP)
+  })
+
+  test('returns unknown for unrecognized keys', () => {
+    expect(parseKey('x')).toBe(KEY.UNKNOWN)
+  })
+})

--- a/tools/glowm/lib/keys.test.ts
+++ b/tools/glowm/lib/keys.test.ts
@@ -43,14 +43,6 @@ describe('parseKey', () => {
     expect(parseKey('N')).toBe(KEY.PREV_HEADER)
   })
 
-  test('recognizes Ctrl+N as next match', () => {
-    expect(parseKey('\x0e')).toBe(KEY.NEXT_MATCH)
-  })
-
-  test('recognizes Ctrl+P as prev match', () => {
-    expect(parseKey('\x10')).toBe(KEY.PREV_MATCH)
-  })
-
   test('recognizes = as info', () => {
     expect(parseKey('=')).toBe(KEY.INFO)
   })

--- a/tools/glowm/lib/keys.ts
+++ b/tools/glowm/lib/keys.ts
@@ -1,0 +1,76 @@
+// lib/keys.ts
+
+export const KEY = {
+  UP: 'up',
+  DOWN: 'down',
+  PAGE_UP: 'page_up',
+  PAGE_DOWN: 'page_down',
+  HALF_UP: 'half_up',
+  HALF_DOWN: 'half_down',
+  TOP: 'top',
+  BOTTOM: 'bottom',
+  SEARCH: 'search',
+  SEARCH_BACK: 'search_back',
+  NEXT_MATCH: 'next_match',
+  PREV_MATCH: 'prev_match',
+  INFO: 'info',
+  QUIT: 'quit',
+  ENTER: 'enter',
+  UNKNOWN: 'unknown',
+} as const
+
+export type KeyAction = (typeof KEY)[keyof typeof KEY]
+
+const KEY_MAP: Record<string, KeyAction> = {
+  // Scroll down
+  'j': KEY.DOWN,
+  '\x1b[B': KEY.DOWN, // Down arrow
+  '\r': KEY.ENTER, // Enter (also scrolls down)
+  '\n': KEY.ENTER,
+
+  // Scroll up
+  'k': KEY.UP,
+  '\x1b[A': KEY.UP, // Up arrow
+
+  // Page down
+  ' ': KEY.PAGE_DOWN,
+  'f': KEY.PAGE_DOWN,
+  '\x06': KEY.PAGE_DOWN, // Ctrl+F
+  '\x1b[6~': KEY.PAGE_DOWN, // Page Down key
+
+  // Page up
+  'b': KEY.PAGE_UP,
+  '\x02': KEY.PAGE_UP, // Ctrl+B
+  '\x1b[5~': KEY.PAGE_UP, // Page Up key
+
+  // Half page
+  'd': KEY.HALF_DOWN,
+  '\x04': KEY.HALF_DOWN, // Ctrl+D
+  'u': KEY.HALF_UP,
+  '\x15': KEY.HALF_UP, // Ctrl+U
+
+  // Jump
+  'g': KEY.TOP,
+  '\x1b[H': KEY.TOP, // Home key
+  'G': KEY.BOTTOM,
+  '\x1b[F': KEY.BOTTOM, // End key
+
+  // Search
+  '/': KEY.SEARCH,
+  '?': KEY.SEARCH_BACK,
+  'n': KEY.NEXT_MATCH,
+  'N': KEY.PREV_MATCH,
+
+  // Info
+  '=': KEY.INFO,
+  '\x07': KEY.INFO, // Ctrl+G
+
+  // Quit
+  'q': KEY.QUIT,
+  '\x03': KEY.QUIT, // Ctrl+C
+}
+
+/** Parse raw key input into action. */
+export function parseKey(data: string): KeyAction {
+  return KEY_MAP[data] ?? KEY.UNKNOWN
+}

--- a/tools/glowm/lib/keys.ts
+++ b/tools/glowm/lib/keys.ts
@@ -13,6 +13,8 @@ export const KEY = {
   SEARCH_BACK: 'search_back',
   NEXT_MATCH: 'next_match',
   PREV_MATCH: 'prev_match',
+  NEXT_HEADER: 'next_header',
+  PREV_HEADER: 'prev_header',
   INFO: 'info',
   QUIT: 'quit',
   ENTER: 'enter',
@@ -58,8 +60,12 @@ const KEY_MAP: Record<string, KeyAction> = {
   // Search
   '/': KEY.SEARCH,
   '?': KEY.SEARCH_BACK,
-  'n': KEY.NEXT_MATCH,
-  'N': KEY.PREV_MATCH,
+  '\x0e': KEY.NEXT_MATCH, // Ctrl+N
+  '\x10': KEY.PREV_MATCH, // Ctrl+P
+
+  // Header navigation
+  'n': KEY.NEXT_HEADER,
+  'N': KEY.PREV_HEADER,
 
   // Info
   '=': KEY.INFO,

--- a/tools/glowm/lib/keys.ts
+++ b/tools/glowm/lib/keys.ts
@@ -3,6 +3,8 @@
 export const KEY = {
   UP: 'up',
   DOWN: 'down',
+  SCROLL_UP: 'scroll_up',
+  SCROLL_DOWN: 'scroll_down',
   PAGE_UP: 'page_up',
   PAGE_DOWN: 'page_down',
   HALF_UP: 'half_up',
@@ -11,8 +13,6 @@ export const KEY = {
   BOTTOM: 'bottom',
   SEARCH: 'search',
   SEARCH_BACK: 'search_back',
-  NEXT_MATCH: 'next_match',
-  PREV_MATCH: 'prev_match',
   NEXT_HEADER: 'next_header',
   PREV_HEADER: 'prev_header',
   INFO: 'info',
@@ -60,8 +60,6 @@ const KEY_MAP: Record<string, KeyAction> = {
   // Search
   '/': KEY.SEARCH,
   '?': KEY.SEARCH_BACK,
-  '\x0e': KEY.NEXT_MATCH, // Ctrl+N
-  '\x10': KEY.PREV_MATCH, // Ctrl+P
 
   // Header navigation
   'n': KEY.NEXT_HEADER,
@@ -76,7 +74,15 @@ const KEY_MAP: Record<string, KeyAction> = {
   '\x03': KEY.QUIT, // Ctrl+C
 }
 
+// SGR mouse scroll: \x1b[<64;col;rowM (up) or \x1b[<65;col;rowM (down)
+const MOUSE_SCROLL_REGEX = /^\x1b\[<(64|65);\d+;\d+M$/
+
 /** Parse raw key input into action. */
 export function parseKey(data: string): KeyAction {
+  // Check for mouse scroll first
+  const mouseMatch = data.match(MOUSE_SCROLL_REGEX)
+  if (mouseMatch) {
+    return mouseMatch[1] === '64' ? KEY.SCROLL_UP : KEY.SCROLL_DOWN
+  }
   return KEY_MAP[data] ?? KEY.UNKNOWN
 }

--- a/tools/glowm/lib/lines.test.ts
+++ b/tools/glowm/lib/lines.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test'
+import { splitIntoLines, wrapLine } from './lines'
+
+describe('wrapLine', () => {
+  test('returns single line if fits', () => {
+    const result = wrapLine('short', 80)
+    expect(result).toEqual(['short'])
+  })
+
+  test('wraps long line at width boundary', () => {
+    const result = wrapLine('abcdefghij', 5)
+    expect(result).toEqual(['abcde', 'fghij'])
+  })
+
+  test('handles ANSI codes correctly', () => {
+    // "red" with color codes should count as 3 visible chars
+    const result = wrapLine('\x1b[31mabcde\x1b[0m', 3)
+    expect(result.length).toBe(2)
+    // First chunk should have the color code + 3 chars
+    expect(result[0]).toContain('\x1b[31m')
+  })
+
+  test('preserves ANSI codes across wrapped lines', () => {
+    const result = wrapLine('\x1b[31mabcdef\x1b[0m', 3)
+    // Each wrapped line should still be red
+    expect(result[0]).toContain('\x1b[31m')
+    expect(result[1]).toContain('\x1b[31m')
+  })
+})
+
+describe('splitIntoLines', () => {
+  test('splits by newline', () => {
+    const result = splitIntoLines('a\nb\nc', 80)
+    expect(result).toEqual([
+      { content: 'a', imageRef: undefined },
+      { content: 'b', imageRef: undefined },
+      { content: 'c', imageRef: undefined },
+    ])
+  })
+
+  test('wraps long lines', () => {
+    const result = splitIntoLines('abcdefghij', 5)
+    expect(result.length).toBe(2)
+    expect(result[0]!.content).toBe('abcde')
+    expect(result[1]!.content).toBe('fghij')
+  })
+
+  test('detects image placeholders', () => {
+    const result = splitIntoLines('text\n\x00IMG:0\x00\nmore', 80)
+    expect(result[1]!.imageRef).toBe('\x00IMG:0\x00')
+  })
+
+  test('handles empty lines', () => {
+    const result = splitIntoLines('a\n\nb', 80)
+    expect(result[1]!.content).toBe('')
+  })
+})

--- a/tools/glowm/lib/lines.test.ts
+++ b/tools/glowm/lib/lines.test.ts
@@ -32,9 +32,9 @@ describe('splitIntoLines', () => {
   test('splits by newline', () => {
     const result = splitIntoLines('a\nb\nc', 80)
     expect(result).toEqual([
-      { content: 'a', imageRef: undefined },
-      { content: 'b', imageRef: undefined },
-      { content: 'c', imageRef: undefined },
+      { content: 'a', isHeader: false },
+      { content: 'b', isHeader: false },
+      { content: 'c', isHeader: false },
     ])
   })
 
@@ -53,5 +53,18 @@ describe('splitIntoLines', () => {
   test('handles empty lines', () => {
     const result = splitIntoLines('a\n\nb', 80)
     expect(result[1]!.content).toBe('')
+  })
+
+  test('detects header markers', () => {
+    const result = splitIntoLines('\x01Header\nText', 80)
+    expect(result[0]!.isHeader).toBe(true)
+    expect(result[0]!.content).toBe('Header')
+    expect(result[1]!.isHeader).toBe(false)
+  })
+
+  test('strips header marker from content', () => {
+    const result = splitIntoLines('\x01## Title', 80)
+    expect(result[0]!.content).toBe('## Title')
+    expect(result[0]!.isHeader).toBe(true)
   })
 })

--- a/tools/glowm/lib/lines.ts
+++ b/tools/glowm/lib/lines.ts
@@ -1,8 +1,10 @@
 import { visibleLength } from './ansi'
+import { HEADING_MARKER } from './renderers'
 
 export type Line = {
   content: string
   imageRef?: string
+  isHeader?: boolean
 }
 
 const IMAGE_PLACEHOLDER_REGEX = /^\x00IMG:\d+\x00$/
@@ -47,23 +49,29 @@ export function wrapLine(line: string, width: number): string[] {
 
 /**
  * Split rendered content into Line objects for pager display.
- * Handles newlines, word wrapping, and image placeholder detection.
+ * Handles newlines, word wrapping, image placeholder detection, and header markers.
  */
 export function splitIntoLines(content: string, width: number): Line[] {
   const rawLines = content.split('\n')
   const result: Line[] = []
 
-  for (const raw of rawLines) {
+  for (let raw of rawLines) {
     // Check for image placeholder
     if (IMAGE_PLACEHOLDER_REGEX.test(raw.trim())) {
       result.push({ content: raw, imageRef: raw.trim() })
       continue
     }
 
+    // Check for header marker
+    const isHeader = raw.startsWith(HEADING_MARKER)
+    if (isHeader) {
+      raw = raw.slice(HEADING_MARKER.length)
+    }
+
     // Wrap long lines
     const wrapped = wrapLine(raw, width)
     for (const segment of wrapped) {
-      result.push({ content: segment, imageRef: undefined })
+      result.push({ content: segment, isHeader })
     }
   }
 

--- a/tools/glowm/lib/lines.ts
+++ b/tools/glowm/lib/lines.ts
@@ -7,7 +7,8 @@ export type Line = {
   isHeader?: boolean
 }
 
-const IMAGE_PLACEHOLDER_REGEX = /^\x00IMG:\d+\x00$/
+// Match placeholder with optional surrounding ANSI codes/whitespace
+const IMAGE_PLACEHOLDER_REGEX = /^(?:\x1b\[[0-9;]*m|\s)*(\x00IMG:\d+\x00)(?:\x1b\[[0-9;]*m|\s)*$/
 
 /**
  * Wrap a single line to fit within width, preserving ANSI codes.
@@ -57,8 +58,9 @@ export function splitIntoLines(content: string, width: number): Line[] {
 
   for (let raw of rawLines) {
     // Check for image placeholder
-    if (IMAGE_PLACEHOLDER_REGEX.test(raw.trim())) {
-      result.push({ content: raw, imageRef: raw.trim() })
+    const imageMatch = raw.match(IMAGE_PLACEHOLDER_REGEX)
+    if (imageMatch) {
+      result.push({ content: raw, imageRef: imageMatch[1] })
       continue
     }
 

--- a/tools/glowm/lib/lines.ts
+++ b/tools/glowm/lib/lines.ts
@@ -1,0 +1,71 @@
+import { visibleLength } from './ansi'
+
+export type Line = {
+  content: string
+  imageRef?: string
+}
+
+const IMAGE_PLACEHOLDER_REGEX = /^\x00IMG:\d+\x00$/
+
+/**
+ * Wrap a single line to fit within width, preserving ANSI codes.
+ * Returns array of wrapped line segments.
+ */
+export function wrapLine(line: string, width: number): string[] {
+  const visLen = visibleLength(line)
+  if (visLen <= width) return [line]
+
+  const result: string[] = []
+  let remaining = line
+  let activeAnsi = '' // Track active ANSI codes to reapply
+
+  while (visibleLength(remaining) > width) {
+    let chunk = ''
+    let visibleCount = 0
+    let i = 0
+
+    while (i < remaining.length && visibleCount < width) {
+      const match = remaining.slice(i).match(/^\x1b\[[0-9;]*m/)
+      if (match) {
+        activeAnsi = match[0] // Track last ANSI code
+        chunk += match[0]
+        i += match[0].length
+      } else {
+        chunk += remaining[i]
+        visibleCount++
+        i++
+      }
+    }
+
+    result.push(chunk)
+    remaining = activeAnsi + remaining.slice(i) // Reapply active ANSI
+  }
+
+  if (remaining) result.push(remaining)
+  return result
+}
+
+/**
+ * Split rendered content into Line objects for pager display.
+ * Handles newlines, word wrapping, and image placeholder detection.
+ */
+export function splitIntoLines(content: string, width: number): Line[] {
+  const rawLines = content.split('\n')
+  const result: Line[] = []
+
+  for (const raw of rawLines) {
+    // Check for image placeholder
+    if (IMAGE_PLACEHOLDER_REGEX.test(raw.trim())) {
+      result.push({ content: raw, imageRef: raw.trim() })
+      continue
+    }
+
+    // Wrap long lines
+    const wrapped = wrapLine(raw, width)
+    for (const segment of wrapped) {
+      result.push({ content: segment, imageRef: undefined })
+    }
+  }
+
+  return result
+}

--- a/tools/glowm/lib/pager.test.ts
+++ b/tools/glowm/lib/pager.test.ts
@@ -1,0 +1,87 @@
+// lib/pager.test.ts
+import { describe, expect, test } from 'bun:test'
+import { createPagerState, scroll, renderViewport } from './pager'
+import type { Line } from './lines'
+
+const makeLines = (n: number): Line[] =>
+  Array.from({ length: n }, (_, i) => ({ content: `Line ${i}`, imageRef: undefined }))
+
+describe('createPagerState', () => {
+  test('initializes with correct dimensions', () => {
+    const lines = makeLines(100)
+    const state = createPagerState(lines, new Map(), 24, 80)
+
+    expect(state.topLine).toBe(0)
+    expect(state.lines.length).toBe(100)
+    expect(state.termHeight).toBe(24)
+    expect(state.termWidth).toBe(80)
+  })
+})
+
+describe('scroll', () => {
+  test('scrolls down by delta', () => {
+    const lines = makeLines(100)
+    const state = createPagerState(lines, new Map(), 24, 80)
+
+    scroll(state, 5)
+    expect(state.topLine).toBe(5)
+  })
+
+  test('scrolls up by negative delta', () => {
+    const lines = makeLines(100)
+    const state = createPagerState(lines, new Map(), 24, 80)
+    state.topLine = 10
+
+    scroll(state, -3)
+    expect(state.topLine).toBe(7)
+  })
+
+  test('clamps at top', () => {
+    const lines = makeLines(100)
+    const state = createPagerState(lines, new Map(), 24, 80)
+    state.topLine = 5
+
+    scroll(state, -10)
+    expect(state.topLine).toBe(0)
+  })
+
+  test('clamps at bottom', () => {
+    const lines = makeLines(100)
+    const state = createPagerState(lines, new Map(), 24, 80)
+
+    scroll(state, 200)
+    // Should stop so last line is visible
+    expect(state.topLine).toBe(100 - 23) // lines - (height - 1 for prompt)
+  })
+})
+
+describe('renderViewport', () => {
+  test('renders visible lines only', () => {
+    const lines = makeLines(100)
+    const state = createPagerState(lines, new Map(), 5, 80)
+    state.topLine = 10
+
+    const output = renderViewport(state)
+    expect(output).toContain('Line 10')
+    expect(output).toContain('Line 13') // 4 lines visible (5 - 1 for prompt)
+    expect(output).not.toContain('Line 9')
+    expect(output).not.toContain('Line 14')
+  })
+
+  test('shows : prompt at bottom', () => {
+    const lines = makeLines(100)
+    const state = createPagerState(lines, new Map(), 5, 80)
+
+    const output = renderViewport(state)
+    expect(output).toContain(':')
+  })
+
+  test('shows (END) when at bottom', () => {
+    const lines = makeLines(10)
+    const state = createPagerState(lines, new Map(), 20, 80)
+    state.topLine = 0 // All lines fit
+
+    const output = renderViewport(state)
+    expect(output).toContain('(END)')
+  })
+})

--- a/tools/glowm/lib/pager.test.ts
+++ b/tools/glowm/lib/pager.test.ts
@@ -1,6 +1,6 @@
 // lib/pager.test.ts
 import { describe, expect, test } from 'bun:test'
-import { createPagerState, scroll, renderViewport } from './pager'
+import { createPagerState, scroll, renderViewport, goTo, isAtEnd, formatInfo } from './pager'
 import type { Line } from './lines'
 
 const makeLines = (n: number): Line[] =>
@@ -83,5 +83,82 @@ describe('renderViewport', () => {
 
     const output = renderViewport(state)
     expect(output).toContain('(END)')
+  })
+})
+
+describe('goTo', () => {
+  test('jumps to specific line', () => {
+    const lines = makeLines(100)
+    const state = createPagerState(lines, new Map(), 24, 80)
+
+    goTo(state, 50)
+    expect(state.topLine).toBe(50)
+  })
+
+  test('clamps to top when negative', () => {
+    const lines = makeLines(100)
+    const state = createPagerState(lines, new Map(), 24, 80)
+
+    goTo(state, -10)
+    expect(state.topLine).toBe(0)
+  })
+
+  test('clamps to max when beyond end', () => {
+    const lines = makeLines(100)
+    const state = createPagerState(lines, new Map(), 24, 80)
+
+    goTo(state, 200)
+    expect(state.topLine).toBe(100 - 23) // lines - (height - 1 for prompt)
+  })
+})
+
+describe('isAtEnd', () => {
+  test('returns false when not at end', () => {
+    const lines = makeLines(100)
+    const state = createPagerState(lines, new Map(), 24, 80)
+
+    expect(isAtEnd(state)).toBe(false)
+  })
+
+  test('returns true when scrolled to end', () => {
+    const lines = makeLines(100)
+    const state = createPagerState(lines, new Map(), 24, 80)
+    state.topLine = 100 - 23 // max scroll position
+
+    expect(isAtEnd(state)).toBe(true)
+  })
+
+  test('returns true when content fits in viewport', () => {
+    const lines = makeLines(10)
+    const state = createPagerState(lines, new Map(), 24, 80)
+
+    expect(isAtEnd(state)).toBe(true)
+  })
+})
+
+describe('formatInfo', () => {
+  test('formats position info correctly', () => {
+    const lines = makeLines(100)
+    const state = createPagerState(lines, new Map(), 24, 80)
+    state.topLine = 10
+
+    const info = formatInfo(state)
+    expect(info).toBe('lines 11-33/100 (33%)')
+  })
+
+  test('shows 100% at end', () => {
+    const lines = makeLines(100)
+    const state = createPagerState(lines, new Map(), 24, 80)
+    state.topLine = 77 // max top
+
+    const info = formatInfo(state)
+    expect(info).toBe('lines 78-100/100 (100%)')
+  })
+
+  test('handles empty lines array', () => {
+    const state = createPagerState([], new Map(), 24, 80)
+
+    const info = formatInfo(state)
+    expect(info).toBe('lines 0-0/0 (0%)')
   })
 })

--- a/tools/glowm/lib/pager.ts
+++ b/tools/glowm/lib/pager.ts
@@ -1,0 +1,98 @@
+import { ANSI } from './ansi'
+import type { Line } from './lines'
+import type { Match } from './search'
+import { highlightLine } from './search'
+
+type ImageData = {
+  buffer: Buffer
+  alt: string
+}
+
+export type PagerState = {
+  lines: Line[]
+  images: Map<string, ImageData>
+  topLine: number
+  termHeight: number
+  termWidth: number
+  searchPattern: string | null
+  searchMatches: Match[]
+  searchIndex: number
+}
+
+export function createPagerState(
+  lines: Line[],
+  images: Map<string, ImageData>,
+  termHeight: number,
+  termWidth: number
+): PagerState {
+  return {
+    lines,
+    images,
+    topLine: 0,
+    termHeight,
+    termWidth,
+    searchPattern: null,
+    searchMatches: [],
+    searchIndex: -1,
+  }
+}
+
+/** Scroll by delta lines, clamping to bounds. */
+export function scroll(state: PagerState, delta: number): void {
+  const viewportHeight = state.termHeight - 1 // Reserve 1 line for prompt
+  const maxTop = Math.max(0, state.lines.length - viewportHeight)
+
+  state.topLine = Math.max(0, Math.min(maxTop, state.topLine + delta))
+}
+
+/** Jump to specific line. */
+export function goTo(state: PagerState, line: number): void {
+  const viewportHeight = state.termHeight - 1
+  const maxTop = Math.max(0, state.lines.length - viewportHeight)
+
+  state.topLine = Math.max(0, Math.min(maxTop, line))
+}
+
+/** Check if at end of content. */
+export function isAtEnd(state: PagerState): boolean {
+  const viewportHeight = state.termHeight - 1
+  return state.topLine + viewportHeight >= state.lines.length
+}
+
+/** Render current viewport to string (for testing). */
+export function renderViewport(state: PagerState): string {
+  const viewportHeight = state.termHeight - 1
+  const endLine = Math.min(state.topLine + viewportHeight, state.lines.length)
+
+  let output = ANSI.clearScreen + ANSI.cursorHome
+
+  for (let i = state.topLine; i < endLine; i++) {
+    const line = state.lines[i]!
+
+    if (line.imageRef) {
+      // Image placeholder - will be rendered separately in actual pager
+      output += `[Image]\n`
+    } else {
+      let content = line.content
+      // Apply search highlighting
+      if (state.searchMatches.length > 0) {
+        content = highlightLine(content, state.searchMatches, i)
+      }
+      output += content + '\n'
+    }
+  }
+
+  // Prompt line
+  output += isAtEnd(state) ? '(END)' : ':'
+
+  return output
+}
+
+/** Format info line for = command. */
+export function formatInfo(state: PagerState): string {
+  const viewportHeight = state.termHeight - 1
+  const endLine = Math.min(state.topLine + viewportHeight, state.lines.length)
+  const percent = Math.round((endLine / state.lines.length) * 100)
+
+  return `lines ${state.topLine + 1}-${endLine}/${state.lines.length} (${percent}%)`
+}

--- a/tools/glowm/lib/pager.ts
+++ b/tools/glowm/lib/pager.ts
@@ -124,14 +124,24 @@ export async function runPager(
     // Preserve relative position
     const relativePos = state.topLine / Math.max(1, state.lines.length)
 
-    // Preserve search state
-    const { searchPattern, searchMatches, searchIndex } = state
+    // Preserve search pattern
+    const { searchPattern, searchIndex } = state
 
     state = createPagerState(lines, images, termHeight, termWidth)
-    state.topLine = Math.floor(relativePos * state.lines.length)
+
+    // Restore position with bounds checking
+    const targetLine = Math.floor(relativePos * state.lines.length)
+    goTo(state, targetLine)
+
+    // Recalculate search matches for new line structure
     state.searchPattern = searchPattern
-    state.searchMatches = searchMatches
-    state.searchIndex = searchIndex
+    if (searchPattern) {
+      state.searchMatches = findMatches(state.lines, searchPattern)
+      state.searchIndex = Math.min(searchIndex, Math.max(0, state.searchMatches.length - 1))
+    } else {
+      state.searchMatches = []
+      state.searchIndex = -1
+    }
 
     render(state)
   }

--- a/tools/glowm/lib/pager.ts
+++ b/tools/glowm/lib/pager.ts
@@ -90,6 +90,10 @@ export function renderViewport(state: PagerState): string {
 
 /** Format info line for = command. */
 export function formatInfo(state: PagerState): string {
+  if (state.lines.length === 0) {
+    return 'lines 0-0/0 (0%)'
+  }
+
   const viewportHeight = state.termHeight - 1
   const endLine = Math.min(state.topLine + viewportHeight, state.lines.length)
   const percent = Math.round((endLine / state.lines.length) * 100)

--- a/tools/glowm/lib/pager.ts
+++ b/tools/glowm/lib/pager.ts
@@ -1,7 +1,9 @@
 import { ANSI } from './ansi'
+import { parseKey, KEY } from './keys'
 import type { Line } from './lines'
+import { splitIntoLines } from './lines'
 import type { Match } from './search'
-import { highlightLine } from './search'
+import { findMatches, highlightLine } from './search'
 
 type ImageData = {
   buffer: Buffer
@@ -99,4 +101,190 @@ export function formatInfo(state: PagerState): string {
   const percent = Math.round((endLine / state.lines.length) * 100)
 
   return `lines ${state.topLine + 1}-${endLine}/${state.lines.length} (${percent}%)`
+}
+
+/**
+ * Run interactive pager. Returns when user quits.
+ */
+export async function runPager(
+  content: string,
+  images: Map<string, ImageData>
+): Promise<void> {
+  const termHeight = process.stdout.rows || 24
+  const termWidth = process.stdout.columns || 80
+
+  const lines = splitIntoLines(content, termWidth)
+  const state = createPagerState(lines, images, termHeight, termWidth)
+
+  // Set up raw mode
+  if (process.stdin.isTTY) {
+    process.stdin.setRawMode(true)
+  }
+  process.stdin.resume()
+  process.stdout.write(ANSI.cursorHide)
+
+  // Initial render
+  render(state)
+
+  return new Promise<void>((resolve) => {
+    const handleKey = async (data: Buffer) => {
+      const key = parseKey(data.toString())
+      const viewportHeight = state.termHeight - 1
+
+      switch (key) {
+        case KEY.DOWN:
+        case KEY.ENTER:
+          scroll(state, 1)
+          break
+        case KEY.UP:
+          scroll(state, -1)
+          break
+        case KEY.PAGE_DOWN:
+          scroll(state, viewportHeight)
+          break
+        case KEY.PAGE_UP:
+          scroll(state, -viewportHeight)
+          break
+        case KEY.HALF_DOWN:
+          scroll(state, Math.floor(viewportHeight / 2))
+          break
+        case KEY.HALF_UP:
+          scroll(state, -Math.floor(viewportHeight / 2))
+          break
+        case KEY.TOP:
+          goTo(state, 0)
+          break
+        case KEY.BOTTOM:
+          goTo(state, state.lines.length)
+          break
+        case KEY.SEARCH:
+          await handleSearch(state, 'forward')
+          break
+        case KEY.SEARCH_BACK:
+          await handleSearch(state, 'backward')
+          break
+        case KEY.NEXT_MATCH:
+          jumpToMatch(state, 1)
+          break
+        case KEY.PREV_MATCH:
+          jumpToMatch(state, -1)
+          break
+        case KEY.INFO:
+          showInfo(state)
+          return // Don't re-render, info shows on prompt line
+        case KEY.QUIT:
+          cleanup()
+          resolve()
+          return
+      }
+
+      render(state)
+    }
+
+    const cleanup = () => {
+      process.stdin.removeListener('data', handleKey)
+      process.stdin.pause()
+      if (process.stdin.isTTY) {
+        process.stdin.setRawMode(false)
+      }
+      process.stdout.write(ANSI.cursorShow)
+      process.stdout.write(ANSI.clearScreen + ANSI.cursorHome)
+    }
+
+    process.stdin.on('data', handleKey)
+  })
+}
+
+/** Render current state to terminal. */
+function render(state: PagerState): void {
+  const output = renderViewport(state)
+  process.stdout.write(output)
+}
+
+/** Handle search input. */
+async function handleSearch(
+  state: PagerState,
+  direction: 'forward' | 'backward'
+): Promise<void> {
+  const prompt = direction === 'forward' ? '/' : '?'
+
+  // Show search prompt
+  process.stdout.write(
+    ANSI.cursorTo(state.termHeight, 1) + ANSI.eraseLine + prompt
+  )
+  process.stdout.write(ANSI.cursorShow)
+
+  const pattern = await readLine()
+
+  process.stdout.write(ANSI.cursorHide)
+
+  if (pattern) {
+    state.searchPattern = pattern
+    state.searchMatches = findMatches(state.lines, pattern)
+    state.searchIndex = -1
+
+    if (state.searchMatches.length > 0) {
+      // Jump to first match (or last for backward)
+      if (direction === 'forward') {
+        jumpToMatch(state, 1)
+      } else {
+        state.searchIndex = state.searchMatches.length
+        jumpToMatch(state, -1)
+      }
+    }
+  }
+}
+
+/** Read a line of input from user. */
+function readLine(): Promise<string> {
+  return new Promise((resolve) => {
+    let buffer = ''
+
+    const handler = (data: Buffer) => {
+      const char = data.toString()
+
+      if (char === '\r' || char === '\n') {
+        process.stdin.removeListener('data', handler)
+        resolve(buffer)
+      } else if (char === '\x7f' || char === '\x08') {
+        // Backspace
+        if (buffer.length > 0) {
+          buffer = buffer.slice(0, -1)
+          process.stdout.write('\b \b')
+        }
+      } else if (char === '\x1b' || char === '\x03') {
+        // Escape or Ctrl+C - cancel
+        process.stdin.removeListener('data', handler)
+        resolve('')
+      } else if (char >= ' ') {
+        buffer += char
+        process.stdout.write(char)
+      }
+    }
+
+    process.stdin.on('data', handler)
+  })
+}
+
+/** Jump to next/prev search match. */
+function jumpToMatch(state: PagerState, direction: 1 | -1): void {
+  if (state.searchMatches.length === 0) return
+
+  state.searchIndex += direction
+
+  // Wrap around
+  if (state.searchIndex >= state.searchMatches.length) {
+    state.searchIndex = 0
+  } else if (state.searchIndex < 0) {
+    state.searchIndex = state.searchMatches.length - 1
+  }
+
+  const match = state.searchMatches[state.searchIndex]!
+  goTo(state, match.lineIndex)
+}
+
+/** Show info on prompt line. */
+function showInfo(state: PagerState): void {
+  const info = formatInfo(state)
+  process.stdout.write(ANSI.cursorTo(state.termHeight, 1) + ANSI.eraseLine + info)
 }

--- a/tools/glowm/lib/pager.ts
+++ b/tools/glowm/lib/pager.ts
@@ -201,6 +201,12 @@ export async function runPager(
         case KEY.PREV_MATCH:
           jumpToMatch(state, -1)
           break
+        case KEY.NEXT_HEADER:
+          jumpToHeader(state, 1)
+          break
+        case KEY.PREV_HEADER:
+          jumpToHeader(state, -1)
+          break
         case KEY.INFO:
           showInfo(state)
           return // Don't re-render, info shows on prompt line
@@ -362,6 +368,31 @@ function jumpToMatch(state: PagerState, direction: 1 | -1): void {
 
   const match = state.searchMatches[state.searchIndex]!
   goTo(state, match.lineIndex)
+}
+
+/** Get indices of all header lines. */
+function getHeaderIndices(state: PagerState): number[] {
+  const indices: number[] = []
+  for (let i = 0; i < state.lines.length; i++) {
+    if (state.lines[i]!.isHeader) {
+      indices.push(i)
+    }
+  }
+  return indices
+}
+
+/** Jump to next/prev header. */
+function jumpToHeader(state: PagerState, direction: 1 | -1): void {
+  const headers = getHeaderIndices(state)
+  if (headers.length === 0) return
+
+  if (direction === 1) {
+    const next = headers.find(i => i > state.topLine)
+    if (next !== undefined) state.topLine = next
+  } else {
+    const prev = headers.findLast(i => i < state.topLine)
+    if (prev !== undefined) state.topLine = prev
+  }
 }
 
 /** Show info on prompt line. */

--- a/tools/glowm/lib/renderers.ts
+++ b/tools/glowm/lib/renderers.ts
@@ -14,6 +14,9 @@ const TAB = ' '.repeat(INDENT)
 const ANSI_REGEX = /\x1b\[[0-9;]*m/g
 const LEADING_TAB_REGEX = new RegExp(`^${TAB}`)
 
+/** Marker prepended to heading lines for pager detection. */
+export const HEADING_MARKER = '\x01'
+
 export { INDENT }
 
 export const MERMAID_BLOCK_REGEX = /```mermaid\s*\n([\s\S]*?)```/g
@@ -110,7 +113,7 @@ export function addIndent(ext: TerminalExtension): void {
     if (!result) return result
     return result
       .split('\n')
-      .map(line => (line.trim() ? TAB + line : line))
+      .map(line => (line.trim() ? HEADING_MARKER + TAB + line : line))
       .join('\n')
   }
 }

--- a/tools/glowm/lib/search.test.ts
+++ b/tools/glowm/lib/search.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from 'bun:test'
+import { findMatches, highlightLine } from './search'
+import type { Line } from './lines'
+
+describe('findMatches', () => {
+  test('finds matches across lines', () => {
+    const lines: Line[] = [
+      { content: 'hello world', imageRef: undefined },
+      { content: 'world hello', imageRef: undefined },
+    ]
+    const matches = findMatches(lines, 'hello')
+
+    expect(matches.length).toBe(2)
+    expect(matches[0]).toEqual({ lineIndex: 0, start: 0, end: 5 })
+    expect(matches[1]).toEqual({ lineIndex: 1, start: 6, end: 11 })
+  })
+
+  test('finds multiple matches on same line', () => {
+    const lines: Line[] = [{ content: 'foo bar foo', imageRef: undefined }]
+    const matches = findMatches(lines, 'foo')
+
+    expect(matches.length).toBe(2)
+    expect(matches[0]).toEqual({ lineIndex: 0, start: 0, end: 3 })
+    expect(matches[1]).toEqual({ lineIndex: 0, start: 8, end: 11 })
+  })
+
+  test('ignores image placeholder lines', () => {
+    const lines: Line[] = [
+      { content: 'hello', imageRef: undefined },
+      { content: '\x00IMG:0\x00', imageRef: '\x00IMG:0\x00' },
+      { content: 'hello', imageRef: undefined },
+    ]
+    const matches = findMatches(lines, 'hello')
+
+    expect(matches.length).toBe(2)
+    expect(matches[0]!.lineIndex).toBe(0)
+    expect(matches[1]!.lineIndex).toBe(2)
+  })
+
+  test('case insensitive by default', () => {
+    const lines: Line[] = [{ content: 'Hello HELLO hello', imageRef: undefined }]
+    const matches = findMatches(lines, 'hello')
+
+    expect(matches.length).toBe(3)
+  })
+
+  test('returns empty array for no matches', () => {
+    const lines: Line[] = [{ content: 'hello world', imageRef: undefined }]
+    const matches = findMatches(lines, 'xyz')
+
+    expect(matches).toEqual([])
+  })
+
+  test('searches visible text ignoring ANSI codes', () => {
+    const lines: Line[] = [{ content: '\x1b[31mhello\x1b[0m', imageRef: undefined }]
+    const matches = findMatches(lines, 'hello')
+
+    expect(matches.length).toBe(1)
+    expect(matches[0]).toEqual({ lineIndex: 0, start: 0, end: 5 })
+  })
+})
+
+describe('highlightLine', () => {
+  test('highlights matches on line', () => {
+    const result = highlightLine('hello world', [{ lineIndex: 0, start: 0, end: 5 }], 0)
+    expect(result).toContain('\x1b[7m')
+    expect(result).toContain('hello')
+  })
+
+  test('highlights multiple matches', () => {
+    const matches = [
+      { lineIndex: 0, start: 0, end: 3 },
+      { lineIndex: 0, start: 8, end: 11 },
+    ]
+    const result = highlightLine('foo bar foo', matches, 0)
+    // Both "foo" should be highlighted
+    expect((result.match(/\x1b\[7m/g) || []).length).toBe(2)
+  })
+
+  test('returns original if no matches for this line', () => {
+    const result = highlightLine('hello', [{ lineIndex: 1, start: 0, end: 5 }], 0)
+    expect(result).toBe('hello')
+  })
+})

--- a/tools/glowm/lib/search.ts
+++ b/tools/glowm/lib/search.ts
@@ -1,0 +1,57 @@
+import { stripAnsi, injectHighlight } from './ansi'
+import type { Line } from './lines'
+
+export type Match = {
+  lineIndex: number
+  start: number // visible char index
+  end: number // visible char index (exclusive)
+}
+
+/**
+ * Find all matches of pattern in lines.
+ * Searches visible text (ignoring ANSI codes).
+ */
+export function findMatches(lines: Line[], pattern: string): Match[] {
+  if (!pattern) return []
+
+  const matches: Match[] = []
+  const regex = new RegExp(escapeRegex(pattern), 'gi')
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!
+    if (line.imageRef) continue // Skip image lines
+
+    const visible = stripAnsi(line.content)
+    let match: RegExpExecArray | null
+
+    while ((match = regex.exec(visible)) !== null) {
+      matches.push({
+        lineIndex: i,
+        start: match.index,
+        end: match.index + match[0].length,
+      })
+    }
+  }
+
+  return matches
+}
+
+/**
+ * Apply highlight to all matches on a specific line.
+ */
+export function highlightLine(content: string, matches: Match[], lineIndex: number): string {
+  const lineMatches = matches
+    .filter((m) => m.lineIndex === lineIndex)
+    .sort((a, b) => b.start - a.start) // Process from end to preserve indices
+
+  let result = content
+  for (const match of lineMatches) {
+    result = injectHighlight(result, match.start, match.end)
+  }
+
+  return result
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}

--- a/tools/glowm/lib/utils.ts
+++ b/tools/glowm/lib/utils.ts
@@ -1,7 +1,5 @@
-/** Reads markdown from file path argument or stdin. */
-export async function readInput(): Promise<string> {
-  const filePath = process.argv[2]
-
+/** Reads markdown from file path or stdin. */
+export async function readInput(filePath?: string): Promise<string> {
   if (filePath) {
     const file = Bun.file(filePath)
     if (!(await file.exists())) {


### PR DESCRIPTION
# Overview

Adds a less-style interactive pager to glowm for viewing long markdown documents. The pager activates automatically when content exceeds terminal height, with `--no-pager` flag to disable.

## Key Changes

- Interactive pager with less-compatible keybindings
  - Scroll: j/k, arrows, space/b, d/u, g/G
  - Search: `/` forward, `?` backward with match highlighting
  - Header navigation: n/N to jump between headers
  - Mouse scroll support via SGR protocol
  - Info display with `=`

- Line wrapping that preserves ANSI escape codes
  - Splits content into Line objects for viewport display
  - Handles image placeholders and header markers

- Image handling in pager mode
  - Shows framed box with alt text instead of rendering images
  - Prevents layout issues from variable image heights

- Terminal resize handling
  - Re-wraps content for new width
  - Preserves relative scroll position and search state

## Design Decisions

The pager uses a state machine with `PagerState` holding lines, scroll position, terminal dimensions, and search state. Rendering writes directly to stdout with ANSI clear/cursor sequences rather than using a canvas abstraction.

Images display as styled placeholder boxes in pager mode because terminal image rendering (Kitty protocol or ANSI blocks) doesn't integrate well with viewport scrolling. The non-pager mode still renders actual images.

Header navigation detects headers via a `HEADING_MARKER` character injected during markdown rendering, stripped before final output.

## Overall Flow

```mermaid
sequenceDiagram
    participant User
    participant CLI
    participant Pager
    participant Render

    User->>CLI: glowm file.md
    CLI->>CLI: Render markdown
    CLI->>CLI: Check content height vs terminal
    alt Content fits
        CLI->>User: Output directly
    else Content exceeds terminal
        CLI->>Pager: runPager(content, images)
        Pager->>Render: Initial render
        loop Input handling
            User->>Pager: Keypress/scroll
            Pager->>Pager: Update state
            Pager->>Render: Re-render viewport
        end
        User->>Pager: q
        Pager->>CLI: Cleanup and exit
    end
```