### PR TITLE
feat(userscripts): update google search sidebar for current DOM

### DIFF
--- a/userscripts/google-search-sidebar.user.js
+++ b/userscripts/google-search-sidebar.user.js
@@ -1,220 +1,194 @@
 // ==UserScript==
-// @name            Google Search Sidebar
+// @name            Google Search Sidebar (Updated)
 // @namespace       jmln.tw
-// @version         0.4.3
-// @description     A user script and user style to move Google search tools to sidebar.
+// @version         0.5.0
+// @description     Move Google search tools (time, verbatim filters) to a persistent left sidebar
 // @icon            https://www.google.com/s2/favicons?sz=64&domain=google.com
-// @author          Jimmy Lin
+// @author          Jimmy Lin (original), Updated 2026
 // @license         MIT
 // @homepageURL     https://github.com/jmlntw/google-search-sidebar
 // @supportURL      https://github.com/jmlntw/google-search-sidebar/issues
-// @include         /^https:\/\/(?:ipv4|ipv6|www)\.google\.(?:[a-z\.]+)\/search\?(?:.+&)?q=[^&]+(?:&.+)?$/
-// @exclude         /^https:\/\/(?:ipv4|ipv6|www)\.google\.(?:[a-z\.]+)\/search\?(?:.+&)?tbm=lcl(?:&.+)?$/
-// @run-at          document-end
+// @match           *://www.google.com/search*
+// @match           *://www.google.co.*/search*
+// @match           *://www.google.com.*/search*
+// @exclude         *://www.google.*/search*tbm=*
+// @exclude         *://www.google.*/search*udm=*
+// @run-at          document-start
 // @grant           none
 // ==/UserScript==
 
-function GM_addStyle(css) {
+;(() => {
+  'use strict'
+
   const style = document.createElement('style')
-  style.type = 'text/css'
-  style.textContent = css
-  document.head.appendChild(style)
-  return style
-}
-
-GM_addStyle(`
-  /** CSS Variables **/
-
-  :root {
-    --user-sidebar-width: 180px;
-    --user-sidebar-spacer: 20px;
-    --user-sidebar-primary-color: #dd4b39;
-    --user-action-menu-spacer: 2px;
-    --user-action-menu-background: rgba(0, 0, 0, 0.1);
-    --user-action-menu-font-size: 85%;
-  }
-
-  /** Navigation Bar **/
-
-  /**
-   * 1. Hide "Tools" toggle button on the navigation bar.
-   */
-  #hdtb-tls {
-    display: none !important; /* 1. */
-  }
-
-  /** Search Menu **/
-
-  /**
-   * 1. Reset all CSS properties of the search menu wrapper.
-   * 2. Show the search menu wrapper in the proper position.
-   */
-  #hdtbMenus {
-    all: unset !important; /* 1. */
-    display: block !important; /* 2. */
-    position: absolute !important; /* 2. */
-  }
-
-  /**
-   * 1. Reset all CSS properties of the search menu parent.
-   * 2. Place search menus vertically.
-   * 3. Set the gap space between each search menu.
-   */
-  #hdtbMenus div[id^="tn_"][id$="_1"] {
-    all: unset !important; /* 1. */
-    display: flex !important; /* 2. */
-    flex-direction: column !important; /* 2. */
-    gap: var(--user-sidebar-spacer) !important; /* 3. */
-  }
-
-  /**
-   * 1. Remove the leading space of the search menu wrapper.
-   */
-  #hdtbMenus div[id^="tn_"][id$="_1"] > div:nth-child(1) {
-    display: none !important; /* 1. */
-  }
-
-  /**
-   * 1. Hide the menu toggle button.
-   * 2. Reset all CSS properties of the dropdown menu.
-   * 3. Show the dropdown menu in the proper position.
-   * 4. Set the sidebar width with paddings.
-   */
-  #hdtbMenus div[id^="tn_"][id$="_1"] g-popup > div:nth-child(1) {
-    display: none !important; /* 1. */
-  }
-  #hdtbMenus div[id^="tn_"][id$="_1"] g-popup > div:nth-child(2) {
-    all: unset !important; /* 2. */
-    display: block !important; /* 3. */
-    position: static !important; /* 3. */
-    width: calc(var(--user-sidebar-width) - 20px) !important; /* 4. */
-    max-width: calc(var(--user-sidebar-width) - 20px) !important; /* 4. */
-  }
-
-  /**
-   * 1. Remove the check image on the active menu item.
-   * 2. Set the styles of the active menu item.
-   */
-  #hdtbMenus div[id^="tn_"][id$="_1"] g-menu-item.nvELY {
-    background-image: unset !important; /* 1. */
-    color: var(--user-sidebar-primary-color) !important; /* 2. */
-    font-weight: bolder !important; /* 2. */
-  }
-
-  /**
-   * 1. Set the styles of "Clear" menu item on the sidebar.
-   */
-  #hdtbMenus div[id^="tn_"][id$="_1"] > a.hdtb-mn-hd {
-    padding: 4px 32px !important; /* 1. */
-  }
-  #hdtbMenus div[id^="tn_"][id$="_1"] > a.hdtb-mn-hd:hover {
-    background-color: rgba(0, 0, 0, 0.1) !important; /* 1. */
-    text-decoration: unset !important; /* 1. */
-  }
-
-  /**
-   * 1. Fix the position of the label showing "About ***,*** results...".
-   */
-  #appbar div.LHJvCe {
-    top: unset !important; /* 1. */
-    opacity: unset !important; /* 1. */
-  }
-
-  /** Main Page Content **/
-
-  /**
-   * 1. Set the proper position of the main page content.
-   *    (No "!important" here to make Shopping search display correctly.)
-   */
-  #appbar,
-  #center_col,
-  #rcnt div.M8OgIe {
-    margin-left: var(--user-sidebar-width); /* 1. */
-  }
-
-  /**
-   * 1. Set the proper position of the right information block.
-   *    ("--rhs-margin" is the CSS variable defined by Google.)
-   */
-  #rhs {
-    margin-left: var(--rhs-margin); /* 1. */
-  }
-
-  /**
-   * Do not move the right block to the bottom of the page if there's not enough
-   * space.
-   */
-  @supports (selector(:has(p))) {
-    #rcnt:has(#center_col:first-child + #rhs) {
-      flex-wrap: nowrap !important;
+  style.textContent = `
+    /** CSS Variables **/
+    :root {
+      --sidebar-width: 140px;
+      --sidebar-padding: 16px;
+      --sidebar-bg: #202124;
+      --sidebar-top: 150px;
+      --sidebar-primary: #ff6a34;
     }
-  }
 
-  /** Action Menu **/
+    /** Hide the "Tools" toggle button - we're showing tools permanently **/
+    #hdtb-tls {
+      display: none !important;
+    }
 
-  /**
-   * 1. Hide the dropdown arrow.
-   */
-  div.g g-popup > div {
-    display: none !important; /* 1. */
-  }
+    /** Tools container - make it a fixed sidebar **/
+    #top_nav #hdtb {
+      position: fixed !important;
+      left: 0 !important;
+      top: var(--sidebar-top) !important;
+      width: var(--sidebar-width) !important;
+      height: auto !important;
+      max-height: calc(100vh - var(--sidebar-top) - 20px) !important;
+      overflow-y: auto !important;
+      overflow-x: hidden !important;
+      background: transparent !important;
+      padding: var(--sidebar-padding) !important;
+      z-index: 100 !important;
+    }
 
-  /**
-   * 1. Reset all CSS properties of the dropdown menu.
-   * 2. Show the dropdown menu in the proper position.
-   */
-  div.g div.pkWBse {
-    all: unset !important; /* 1. */
-    display: inline-block !important; /* 2. */
-  }
+    /** Filter menus container - vertical layout **/
+    #hdtb .pZvJc {
+      display: flex !important;
+      flex-direction: column !important;
+      gap: 16px !important;
+    }
 
-  /**
-   * 1. Reset all CSS properties of the dropdown menu.
-   * 2. Place the menu item horizontally.
-   * 3. Set the gap space between each menu item.
-   */
-  div.g div.pkWBse g-menu {
-    all: unset !important; /* 1. */
-    display: flex !important; /* 2. */
-    flex-direction: row !important; /* 2. */
-    gap: var(--user-action-menu-spacer) !important; /* 3. */
-  }
-  div.g div.pkWBse g-menu-item {
-    all: unset !important; /* 1. */
-  }
-  div.g div.pkWBse g-menu-item > div {
-    all: unset !important; /* 1. */
-  }
+    /** Hide the collapsed toggle buttons, show expanded menus **/
+    #hdtb .pZvJc .HPvrce {
+      display: none !important;
+    }
 
-  /**
-   * 1. Set the styles of the dropdown menu item.
-   */
-  div.g div.pkWBse g-menu-item a {
-    padding: 0 5px !important; /* 1. */
-    background-color: var(--user-action-menu-background) !important; /* 1. */
-    font-size: var(--user-action-menu-font-size) !important; /* 1. */
-  }
+    /** Dropdown wrapper - always show **/
+    #hdtb .R0DW9c {
+      display: block !important;
+      position: static !important;
+    }
 
-  /**
-   * Hide search time on sidebar
-   */
-  #result-stats > nobr {
-    display: none;
-  }
+    /** Dropdown menu container - always visible **/
+    #hdtb .vH6rvf.FJCJfd {
+      all: unset !important;
+      display: block !important;
+      position: static !important;
+      background: transparent !important;
+      box-shadow: none !important;
+      border: none !important;
+      max-width: none !important;
+      width: 100% !important;
+    }
 
-  /**
-   * Colorize bolded words in search results
-   */
+    /** Menu section headers **/
+    #hdtb .UsmT1 {
+      display: block !important;
+      margin-top: 20px !important;
+      margin-bottom: 4px !important;
+    }
+    #hdtb .UsmT1:first-child {
+      margin-top: 0 !important;
+    }
 
-  em {
-    color: var(--user-sidebar-primary-color) !important;
-  }
+    /** Individual menu toggle (shows current selection) - style as header **/
+    #hdtb .UsmT1 > .XhWQv.sjVJQd {
+      font-weight: 700 !important;
+      color: #9aa0a6 !important;
+      font-size: 11px !important;
+      text-transform: uppercase !important;
+      letter-spacing: 0.5px !important;
+      padding: 4px 0 !important;
+      pointer-events: none !important;
+    }
 
-  /**
-   * Change search result margin left
-   * From: https://github.com/mnghsn/google-search-sidebar/pull/63
-   */
-  #center_col {
-    margin-left: 0;
-  }
-`)
+    /** Hide dropdown arrow on menu toggles **/
+    #hdtb .UsmT1 > .XhWQv.sjVJQd::after {
+      display: none !important;
+    }
+
+    /** Menu items **/
+    #hdtb .XhWQv.sjVJQd {
+      display: block !important;
+      padding: 2px 8px !important;
+      margin: 0 !important;
+      border-radius: 4px !important;
+      color: #e8eaed !important;
+      text-decoration: none !important;
+      font-size: 13px !important;
+      line-height: 1.3 !important;
+      cursor: pointer !important;
+    }
+
+    #hdtb .XhWQv.sjVJQd:hover {
+      background: rgba(255, 255, 255, 0.1) !important;
+    }
+
+    /** Active/selected menu item **/
+    #hdtb .XhWQv.sjVJQd.Wf7Nsf,
+    #hdtb .XhWQv.sjVJQd a[aria-current="page"] {
+      color: var(--sidebar-primary) !important;
+      font-weight: 700 !important;
+      background: transparent !important;
+      background-color: transparent !important;
+    }
+
+    /** Links inside menu items **/
+    #hdtb .XhWQv a,
+    #hdtb .XhWQv span[jsaction] {
+      color: inherit !important;
+      text-decoration: none !important;
+    }
+
+    /** "Clear" and "Advanced Search" links **/
+    #hdtb .UbBYac,
+    #hdtb span[jscontroller="TmFfhf"] {
+      color: #8ab4f8 !important;
+      display: block !important;
+      padding: 6px 8px !important;
+      margin-top: 8px !important;
+    }
+
+    /** Results count - move into sidebar **/
+    #hdtb .qd6zO {
+      margin-top: 16px !important;
+      padding-top: 12px !important;
+      border-top: 1px solid #3c4043 !important;
+      font-size: 12px !important;
+      color: #9aa0a6 !important;
+    }
+
+    /** Divider **/
+    #hdtb .btCOFd {
+      display: none !important;
+    }
+
+    /** Hide search time on sidebar (it's shown elsewhere) **/
+    #result-stats > nobr {
+      display: none !important;
+    }
+
+    /** Shift main content right to make room for sidebar **/
+    #center_col,
+    #appbar {
+      margin-left: calc(var(--sidebar-width) + var(--sidebar-padding)) !important;
+    }
+
+    /** Highlight search terms in results **/
+    em {
+      color: var(--sidebar-primary) !important;
+    }
+
+    /** Custom date range dialog - keep it functional **/
+    #hdtb g-dialog .qk7LXc {
+      position: fixed !important;
+      top: 50% !important;
+      left: 50% !important;
+      transform: translate(-50%, -50%) !important;
+      background: #303134 !important;
+      z-index: 9999 !important;
+    }
+
+  `
+  document.documentElement.appendChild(style)
+})()


### PR DESCRIPTION
# Overview

Updates the Google Search Sidebar userscript to work with Google's current (2026) DOM structure. The original script by Jimmy Lin stopped working after Google restructured their search tools UI.

<img width="1520" height="1278" alt="image" src="https://github.com/user-attachments/assets/f28beee8-ca85-4087-888e-d2cd7a15b9a3" />


## Key Changes

- **Updated CSS selectors for current Google DOM**
  - Replaced `#hdtbMenus` with `#top_nav #hdtb` and related selectors
  - Targets `.pZvJc`, `.XhWQv.sjVJQd`, `.vH6rvf.FJCJfd` for filter menus

- **Persistent sidebar with time/verbatim filters**
  - Fixed position sidebar on the left showing expanded filter options
  - Shifts main content right to accommodate the sidebar
  - Transparent background to avoid visual clutter

- **Search term highlighting**
  - Highlights `<em>` tags (search terms) with the primary color (#ff6a34)

- **Scope limited to "All" results**
  - Excludes Image, Video, News, Shopping searches via `tbm=` and `udm=` URL params

## Design Decisions

The script uses CSS-only approach (same as the original) for maximum compatibility and minimal overhead. The sidebar overlays on top of the page and shifts the main content rather than being positioned absolutely, which handles responsive layouts better.

Selectors target Google's current class names which may change over time. The script runs at `document-start` to inject styles before render, preventing layout shift.